### PR TITLE
added makefile to be able to run anipy-cli from anywhere

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,16 @@
+PREFIX := /usr/local
+
+all: dependencies install
+
+dependencies:
+	pip install -r requirements.txt
+
+install:
+	echo "#!/bin/sh" > $(PREFIX)/bin/anipy-cli
+	echo python $(CURDIR)/main.py >> $(PREFIX)/bin/anipy-cli
+	chmod 0755 $(DESTDIR)$(PREFIX)/bin/anipy-cli
+
+uninstall:
+	$(RM) $(DESTDIR)$(PREFIX)/bin/anipy-cli
+
+.PHONY: all dependencies install uninstall


### PR DESCRIPTION
I'm sure there is a better way to do it, but I added this simple makefile that creates a shell script that runs main.py. It also installs the python dependencies.
With this you should be able to just run "anipy-cli" on a terminal.
