### PR TITLE
Make main.py executable on linux

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 # local imports 
 from src import query, play, history, menu, download, url
 from src.colors import colors


### PR DESCRIPTION
This commit makes it so that main.py can be run by using `./main.py` instead of having to type `python3 main.py`. This is done by making `main.py` executable with chmod and adding a program to run it with (the `#!/usr/bin/python3` at the start of the file).

I also had to change all of the line endings to LF instead of CRLF. That is why the diff is weird.