### PR TITLE
Make player.py use config options

### DIFF
--- a/anipy_cli/player.py
+++ b/anipy_cli/player.py
@@ -2,6 +2,7 @@ import os
 import subprocess as sp 
 
 from .history import history
+from . import config
 
 def mpv(entry):
     """
@@ -12,12 +13,13 @@ def mpv(entry):
     sub_proc.kill()
     """
     
-    media_titel = entry.show_name + " - EP: " + str(entry.ep)
+    media_title = entry.show_name + " - EP: " + str(entry.ep)
                          
     mpv_player_command = [
-                            "mpv", 
-                            f'--force-media-title={media_titel}',
+                            f'{config.mpv_path}', 
+                            f'--force-media-title={media_title}',
                             f'--http-header-fields=Referer: {entry.embed_url}',
+                            f'{config.mpv_commandline_options}',
                             f'{entry.stream_url}'
                          ]
 


### PR DESCRIPTION
As the title suggests, currently the `mpv` function in `player.py` does not respect options set in `config.py`. This PR fixes that and a typo. 

