### PR TITLE
Quality indicator and empty quality_links fix

### DIFF
--- a/anipy_cli/cli.py
+++ b/anipy_cli/cli.py
@@ -134,7 +134,7 @@ class menu():
         clear_console()
         print(
             colors.GREEN + 
-            f"Playing: {self.entry.show_name} | " + 
+            f"Playing: {self.entry.show_name} {self.entry.quality} | " + 
             colors.RED + 
             f"{self.entry.ep}/{self.entry.latest_ep}")
 

--- a/anipy_cli/cli.py
+++ b/anipy_cli/cli.py
@@ -134,7 +134,7 @@ class menu():
         clear_console()
         print(
             colors.GREEN + 
-            f"Playing: {self.entry.show_name} {self.entry.quality} | " + 
+            f"Playing: {self.entry.show_name} | " + 
             colors.RED + 
             f"{self.entry.ep}/{self.entry.latest_ep}")
 

--- a/anipy_cli/download.py
+++ b/anipy_cli/download.py
@@ -37,7 +37,7 @@ class download():
         
         if self.cli:
             print('-'*20)
-            print(f'{colors.CYAN}Downloading:{colors.RED} {self.entry.show_name} EP: {self.entry.ep} - {self.entry.quality} {colors.END}')
+            print(f'{colors.CYAN}Downloading:{colors.RED} {self.entry.show_name} EP: {self.entry.ep} {colors.END}')
 
         if 'm3u8' in self.entry.stream_url:
             print(f'{colors.CYAN}Type:{colors.RED} m3u8')

--- a/anipy_cli/download.py
+++ b/anipy_cli/download.py
@@ -37,7 +37,7 @@ class download():
         
         if self.cli:
             print('-'*20)
-            print(f'{colors.CYAN}Downloading:{colors.RED} {self.entry.show_name} EP: {self.entry.ep} {colors.END}')
+            print(f'{colors.CYAN}Downloading:{colors.RED} {self.entry.show_name} EP: {self.entry.ep} - {self.entry.quality} {colors.END}')
 
         if 'm3u8' in self.entry.stream_url:
             print(f'{colors.CYAN}Type:{colors.RED} m3u8')

--- a/anipy_cli/download.py
+++ b/anipy_cli/download.py
@@ -2,8 +2,7 @@ import requests
 import shutil
 import sys
 from tqdm import tqdm
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter, Retry
 from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import urljoin, urlsplit
 
@@ -37,7 +36,7 @@ class download():
         
         if self.cli:
             print('-'*20)
-            print(f'{colors.CYAN}Downloading:{colors.RED} {self.entry.show_name} EP: {self.entry.ep} {colors.END}')
+            print(f'{colors.CYAN}Downloading:{colors.RED} {self.entry.show_name} EP: {self.entry.ep} - {self.entry.quality} {colors.END}')
 
         if 'm3u8' in self.entry.stream_url:
             print(f'{colors.CYAN}Type:{colors.RED} m3u8')

--- a/anipy_cli/misc.py
+++ b/anipy_cli/misc.py
@@ -30,7 +30,6 @@ class entry:
     stream_url: str = ""
     ep: int = 0
     latest_ep: int = 0
-    quality: str = ""
 
 def clear_console():
     os.system('cls' if os.name == 'nt' else 'clear')

--- a/anipy_cli/misc.py
+++ b/anipy_cli/misc.py
@@ -30,6 +30,7 @@ class entry:
     stream_url: str = ""
     ep: int = 0
     latest_ep: int = 0
+    quality: str = ""
 
 def clear_console():
     os.system('cls' if os.name == 'nt' else 'clear')

--- a/anipy_cli/player.py
+++ b/anipy_cli/player.py
@@ -13,7 +13,8 @@ def mpv(entry):
     sub_proc.kill()
     """
     
-    media_title = entry.show_name + " - EP: " + str(entry.ep)
+    media_title = entry.show_name + " - EP: " + str(entry.ep) + " - " + str(entry.quality)
+
                          
     mpv_player_command = [
                             f'{config.mpv_path}', 

--- a/anipy_cli/player.py
+++ b/anipy_cli/player.py
@@ -12,7 +12,8 @@ def mpv(entry):
     sub_proc.kill()
     """
     
-    media_titel = entry.show_name + " - EP: " + str(entry.ep)
+    media_titel = entry.show_name + " - EP: " + str(entry.ep) + " - " + str(entry.quality)
+
                          
     mpv_player_command = [
                             "mpv", 

--- a/anipy_cli/player.py
+++ b/anipy_cli/player.py
@@ -12,8 +12,7 @@ def mpv(entry):
     sub_proc.kill()
     """
     
-    media_titel = entry.show_name + " - EP: " + str(entry.ep) + " - " + str(entry.quality)
-
+    media_titel = entry.show_name + " - EP: " + str(entry.ep)
                          
     mpv_player_command = [
                             "mpv", 

--- a/anipy_cli/url_handler.py
+++ b/anipy_cli/url_handler.py
@@ -183,10 +183,10 @@ class videourl():
             bytearray(self.pad(video_id+"\n"), "utf-8"))
         ajax = base64.b64encode(encrypted)
 
-        return ajax.decode('utf-8')
+        return str(ajax).replace("'", "")[1:]
 
     def stream_url(self):
-        """
+        """ 
         Fetches stream url and executes
         quality function.
         """
@@ -227,20 +227,18 @@ class videourl():
             quality_links = [x for x in quality_links if not x.startswith('#')]
             qualitys.reverse()
             quality_links.reverse()
-            quality_links = list(filter(None, quality_links))
 
 
-        else:
-            qualitys = []
-            quality_links = []
-            for i in json_data:
-                if i['label'] == 'Auto':
-                    pass
-                else:
-                    qualitys.append(i['label'])
-                    quality_links.append(i['file'])
+        qualitys = []
+        quality_links = []
+        for i in json_data:
+            if i['label'] == 'auto':
+                pass
+            else:
+                qualitys.append(i['label'])
+                quality_links.append(i['file'])
 
-            qualitys = [x.replace(' P', '') for x in qualitys]
+        qualitys = [x.replace(' P', '') for x in qualitys]
 
 
         if self.qual in qualitys:
@@ -253,20 +251,4 @@ class videourl():
             error("quality not avalible, using default")
             q = quality_links[-1]
 
-
-
-        if 'peliscdn' in json_data[0]['file']:
-            self.entry.stream_url = json_data[0]['file'].replace(
-                'playlist.m3u8', '') + q
-        else:
-            self.entry.stream_url = q
-
-
-        chosen_quality = q.split("/")
-        
-        for _qual in chosen_quality:
-
-            if "EP" in _qual:
-                self.entry.quality = _qual.split(".")[4]
-
-        if not self.entry.quality: self.entry.quality = str(qualitys[quality_links.index(q)] + "p")
+        self.entry.stream_url = q

--- a/anipy_cli/url_handler.py
+++ b/anipy_cli/url_handler.py
@@ -2,8 +2,7 @@ import sys
 import json
 import requests
 from urllib.parse import urlsplit, parse_qs
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter, Retry
 import re
 from bs4 import BeautifulSoup
 import binascii
@@ -183,10 +182,10 @@ class videourl():
             bytearray(self.pad(video_id+"\n"), "utf-8"))
         ajax = base64.b64encode(encrypted)
 
-        return str(ajax).replace("'", "")[1:]
+        return ajax.decode('utf-8')
 
     def stream_url(self):
-        """ 
+        """
         Fetches stream url and executes
         quality function.
         """
@@ -194,7 +193,7 @@ class videourl():
             self.embed_url()
 
         ajax = self.decrypt_link()
-        headers = {'x-requested-with': 'XMLHttpRequest'}
+        headers = {'x-requested-with': 'XMLHttpRequest', "referer": "https://gogoanime.film/"}
         data = {'id': ajax, 'time': '69420691337800813569'}
         r = self.session.post(self.ajax_url, headers=headers, data=data)
 
@@ -214,25 +213,33 @@ class videourl():
         the quality option that was picked,
         or the best one avalible.
         """
+
+        self.entry.quality = ""
         if 'peliscdn' in json_data[0]['file']:
             r = self.session.get(json_data[0]['file'], headers={
                                  'referer': self.entry.embed_url})
+
+
             qualitys = re.findall(r'(?<=\d\d\dx)\d+', r.text)
             quality_links = [x for x in r.text.split('\n')]
             quality_links = [x for x in quality_links if not x.startswith('#')]
             qualitys.reverse()
             quality_links.reverse()
+            quality_links = list(filter(None, quality_links))
 
-        qualitys = []
-        quality_links = []
-        for i in json_data:
-            if i['label'] == 'auto':
-                pass
-            else:
-                qualitys.append(i['label'])
-                quality_links.append(i['file'])
 
-        qualitys = [x.replace(' P', '') for x in qualitys]
+        else:
+            qualitys = []
+            quality_links = []
+            for i in json_data:
+                if i['label'] == 'Auto':
+                    pass
+                else:
+                    qualitys.append(i['label'])
+                    quality_links.append(i['file'])
+
+            qualitys = [x.replace(' P', '') for x in qualitys]
+
 
         if self.qual in qualitys:
             q = quality_links[qualitys.index(self.qual)]
@@ -244,8 +251,20 @@ class videourl():
             error("quality not avalible, using default")
             q = quality_links[-1]
 
+
+
         if 'peliscdn' in json_data[0]['file']:
             self.entry.stream_url = json_data[0]['file'].replace(
                 'playlist.m3u8', '') + q
         else:
             self.entry.stream_url = q
+
+
+        chosen_quality = q.split("/")
+        
+        for _qual in chosen_quality:
+
+            if "EP" in _qual:
+                self.entry.quality = _qual.split(".")[4]
+
+        if not self.entry.quality: self.entry.quality = str(qualitys[quality_links.index(q)] + "p")

--- a/anipy_cli/url_handler.py
+++ b/anipy_cli/url_handler.py
@@ -214,14 +214,21 @@ class videourl():
         the quality option that was picked,
         or the best one avalible.
         """
+
+        self.entry.quality = ""
         if 'peliscdn' in json_data[0]['file']:
             r = self.session.get(json_data[0]['file'], headers={
                                  'referer': self.entry.embed_url})
+
+
+
             qualitys = re.findall(r'(?<=\d\d\dx)\d+', r.text)
             quality_links = [x for x in r.text.split('\n')]
             quality_links = [x for x in quality_links if not x.startswith('#')]
             qualitys.reverse()
             quality_links.reverse()
+            quality_links = list(filter(None, quality_links))
+
 
         else:
             qualitys = []
@@ -235,6 +242,7 @@ class videourl():
 
             qualitys = [x.replace(' P', '') for x in qualitys]
 
+
         if self.qual in qualitys:
             q = quality_links[qualitys.index(self.qual)]
         elif self.qual == 'best' or self.qual == None:
@@ -245,8 +253,20 @@ class videourl():
             error("quality not avalible, using default")
             q = quality_links[-1]
 
+
+
         if 'peliscdn' in json_data[0]['file']:
             self.entry.stream_url = json_data[0]['file'].replace(
                 'playlist.m3u8', '') + q
         else:
             self.entry.stream_url = q
+
+
+        chosen_quality = q.split("/")
+        
+        for _qual in chosen_quality:
+
+            if "EP" in _qual:
+                self.entry.quality = _qual.split(".")[4]
+
+        if not self.entry.quality: self.entry.quality = str(qualitys[quality_links.index(q)] + "p")

--- a/anipy_cli/url_handler.py
+++ b/anipy_cli/url_handler.py
@@ -214,20 +214,14 @@ class videourl():
         the quality option that was picked,
         or the best one avalible.
         """
-
-        self.entry.quality = ""
         if 'peliscdn' in json_data[0]['file']:
             r = self.session.get(json_data[0]['file'], headers={
                                  'referer': self.entry.embed_url})
-
-
-
             qualitys = re.findall(r'(?<=\d\d\dx)\d+', r.text)
             quality_links = [x for x in r.text.split('\n')]
             quality_links = [x for x in quality_links if not x.startswith('#')]
             qualitys.reverse()
             quality_links.reverse()
-
 
         qualitys = []
         quality_links = []
@@ -240,7 +234,6 @@ class videourl():
 
         qualitys = [x.replace(' P', '') for x in qualitys]
 
-
         if self.qual in qualitys:
             q = quality_links[qualitys.index(self.qual)]
         elif self.qual == 'best' or self.qual == None:
@@ -251,4 +244,8 @@ class videourl():
             error("quality not avalible, using default")
             q = quality_links[-1]
 
-        self.entry.stream_url = q
+        if 'peliscdn' in json_data[0]['file']:
+            self.entry.stream_url = json_data[0]['file'].replace(
+                'playlist.m3u8', '') + q
+        else:
+            self.entry.stream_url = q


### PR DESCRIPTION
Heyo,

This fixes empty quality links and adds quality indicators for both download and watch:

![image](https://user-images.githubusercontent.com/71786017/156361225-9e486586-ec04-460a-abec-d3a62df5c13c.png)

What do you think?

The links load good today, so it must be the servers being slow yesterday. Tho the download functionality for pelis are still slow.

