### PR TITLE
Add pycrypto to requirements.txt because it is a dependency 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 bs4 
 requests
+pycrypto

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 bs4 
 requests
-pycryptodome
+pycryptodomex
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 bs4 
 requests
-pycrypto
+pycryptodome
+tqdm

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
     description='Little tool in python to watch anime from the terminal (the better way to watch anime)',
     author='sdaqo',
     license='GPL-3.0',
-    install_requires=['bs4', 'requests', 'tqdm', 'pycryptodome'],
+    install_requires=['bs4', 'requests', 'tqdm', 'pycryptodomex'],
     entry_points="[console_scripts]\nanipy-cli=anipy_cli.cli:main",
 )

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
     description='Little tool in python to watch anime from the terminal (the better way to watch anime)',
     author='sdaqo',
     license='GPL-3.0',
-    install_requires=['bs4', 'requests', ''],
+    install_requires=['bs4', 'requests', 'tqdm', 'pycryptodome'],
     entry_points="[console_scripts]\nanipy-cli=anipy_cli.cli:main",
 )


### PR DESCRIPTION
I tried running `anipy-cli -d` and it had the following error message: 
```
Traceback (most recent call last):
  File "/usr/local/bin/anipy-cli", line 4, in <module>
    from anipy_cli import cli
  File "/home/michael/Projects/anipy-cli/anipy_cli/cli.py", line 4, in <module>
    from .url_handler import epHandler, videourl
  File "/home/michael/Projects/anipy-cli/anipy_cli/url_handler.py", line 10, in <module>
    from Crypto.Cipher import AES
ModuleNotFoundError: No module named 'Crypto'
```
So, I looked up "Crypto python module" and found `pycrypto` on PyPI. I installed it with pip, and it worked. Since it was not in `requirements.txt`, I added and made this pull request.