### PR TITLE
More edits to the makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,9 +11,9 @@ install:
 	# old shell script was still there.
 	$(RM) $(PREFIX)/bin/anipy-cli
 	# Make a symlink to anipy-cli that is on the path
-	ln -s "$(CURDIR)/anipy-cli.py" "$(PREFIX)/bin/anipy-cli"
+	ln -s "$(CURDIR)/anipy_cli/run_anipy_cli.py" "$(PREFIX)/bin/anipy-cli"
 	# Make sure that anipy-cli.py is executable
-	chmod +x "anipy-cli.py"
+	chmod +x "$(CURDIR)/anipy_cli/run_anipy_cli.py"
 
 sys-install:
 	# This method does not require the user to keep this git repo folder
@@ -25,20 +25,25 @@ sys-install:
 	# old shell script was still there.
 	$(RM) $(PREFIX)/bin/anipy-cli
 	# Make a symlink to anipy-cli that is on the path
-	ln -s "$(PREFIX)/lib/anipy-cli/anipy-cli.py" "$(PREFIX)/bin/anipy-cli"
+	ln -s "$(PREFIX)/lib/anipy_cli/run_anipy_cli.py" "$(PREFIX)/bin/anipy-cli"
 
 	# Now install the program to lib
-	cp -r $(CURDIR) "$(PREFIX)/lib"
+	cp -r "$(CURDIR)/anipy_cli" "$(PREFIX)/lib"
 
 	# Make it writable, so that the current default config works	
-	chmod -R 777 $(PREFIX)/lib/anipy-cli
+	chmod -R 777 $(PREFIX)/lib/anipy_cli
 
 uninstall:
 	# Get rid of the symlink
 	$(RM) "$(PREFIX)/bin/anipy-cli"
-	# Get rid of program data
+	
+	# Get rid of program data from older sys-install
 	$(RM) "$(PREFIX)/lib/anipy-cli.py"
+	$(RM) -r "$(PREFIX)/lib/anipy-cli"
+
+	# Get rid of program data from the newer sys-install 
 	$(RM) -r "$(PREFIX)/lib/anipy_cli"
+
 
 all: dependencies install
 

--- a/makefile
+++ b/makefile
@@ -33,6 +33,17 @@ sys-install:
 	# Make it writable, so that the current default config works	
 	chmod -R 777 $(PREFIX)/lib/anipy_cli
 
+lib-install:
+	# This uses pip to install anipy-cli as a library
+	python3 setup.py bdist_wheel
+	pip3 install dist/anipy_cli-2.1.0-py3-none-any.whl
+
+clean:
+	# This gets rid of files generated from building via lib-install
+	$(RM) -r build
+	$(RM) -r dist
+	$(RM) -r anipy_cli.egg-info
+
 uninstall:
 	# Get rid of the symlink
 	$(RM) "$(PREFIX)/bin/anipy-cli"
@@ -44,7 +55,6 @@ uninstall:
 	# Get rid of program data from the newer sys-install 
 	$(RM) -r "$(PREFIX)/lib/anipy_cli"
 
-
 all: dependencies install
 
-.PHONY: all dependencies install sys-install uninstall
+.PHONY: all dependencies install sys-install uninstall lib-install clean


### PR DESCRIPTION
This time I:
- Changed the paths used in the makefile because the locations of the cli script changed (for some reason)
- Add a lib-install recipe that builds a wheel and installs it with pip
- Add a clean recipe that gets rid of files generated by the build process used in the lib-install recipe

I also changed the sys-install recipe so that it only move the `anipy_cli` folder to the lib folder instead of the whole repo. I did this because the cli script in now in the anipy_cli folder.  

Potential issue: if the version in `setup.py` is changed, then lib-install will not work properly because the version of the package in the wheel file's name and lib-install uses the name directly (no pattern matching is used). Right now, I am too lazy to figure out how to use `find` or something to get the file name.