### PR TITLE
Fix traceback show when the selected video player is not installed

### DIFF
--- a/anipy_cli/player.py
+++ b/anipy_cli/player.py
@@ -62,7 +62,7 @@ def start_player(entry, rpc_client=None, player=None):
         else:
             sub_proc = sp.Popen(player_command, stdout=sp.PIPE, stderr=sp.DEVNULL)
     except FileNotFoundError as e:
-        print(colors.RED + "Error:" + colors.END, e)
+        print(colors.RED + "Error:", e, colors.END)
         sys.exit()
 
     hist_class = history(entry)

--- a/anipy_cli/player.py
+++ b/anipy_cli/player.py
@@ -62,9 +62,7 @@ def start_player(entry, rpc_client=None, player=None):
         else:
             sub_proc = sp.Popen(player_command, stdout=sp.PIPE, stderr=sp.DEVNULL)
     except FileNotFoundError as e:
-        print(colors.RED 
-        + "Error:" 
-        + colors.END, e)
+        print(colors.RED + "Error:" + colors.END, e)
         sys.exit()
 
     hist_class = history(entry)

--- a/anipy_cli/player.py
+++ b/anipy_cli/player.py
@@ -57,13 +57,14 @@ def start_player(entry, rpc_client=None, player=None):
         sys.exit()
 
     try:
-        
         if os.name in ("nt", "dos"):
             sub_proc = sp.Popen(player_command)
         else:
             sub_proc = sp.Popen(player_command, stdout=sp.PIPE, stderr=sp.DEVNULL)
     except FileNotFoundError as e:
-        print(colors.END + "Error:", e)
+        print(colors.RED 
+        + "Error:" 
+        + colors.END, e)
         sys.exit()
 
     hist_class = history(entry)

--- a/anipy_cli/player.py
+++ b/anipy_cli/player.py
@@ -56,10 +56,15 @@ def start_player(entry, rpc_client=None, player=None):
         error("Specified player is unknown")
         sys.exit()
 
-    if os.name in ("nt", "dos"):
-        sub_proc = sp.Popen(player_command)
-    else:
-        sub_proc = sp.Popen(player_command, stdout=sp.PIPE, stderr=sp.DEVNULL)
+    try:
+        
+        if os.name in ("nt", "dos"):
+            sub_proc = sp.Popen(player_command)
+        else:
+            sub_proc = sp.Popen(player_command, stdout=sp.PIPE, stderr=sp.DEVNULL)
+    except FileNotFoundError as e:
+        print(colors.END + "Error:", e)
+        sys.exit()
 
     hist_class = history(entry)
     hist_class.write_hist()


### PR DESCRIPTION
When the user ran `anipy_cli` with the `-v` or `-s` flags but they have not VLC or Syncplay installed, the program ended abruptly and the python error traceback was printed.

Now it prints a nice error message.