### PR TITLE
Bug: Fixed makefile not working

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,25 +3,25 @@ PREFIX := /usr/local
 dependencies:
 	pip3 install -r requirements.txt
 
-install: 
+install:
 	# Just makes the scipt accessable from the path
-	
-	# Delete the anipy-cli in bin folder so that 
-	# the symlink can be made. It would fail if the 
+
+	# Delete the anipy-cli in bin folder so that
+	# the symlink can be made. It would fail if the
 	# old shell script was still there.
 	$(RM) $(PREFIX)/bin/anipy-cli
 	# Make a symlink to anipy-cli that is on the path
-	ln -s "$(CURDIR)/anipy-cli.py" "$(PREFIX)/bin/anipy-cli"
+	ln -s "$(CURDIR)/anipy_cli.py" "$(PREFIX)/bin/anipy-cli"
 	# Make sure that anipy-cli.py is executable
-	chmod +x "anipy-cli.py"
+	chmod +x "anipy_cli.py"
 
 sys-install:
 	# This method does not require the user to keep this git repo folder
 	mkdir -p "$(PREFIX)/lib"
 	mkdir -p "$(PREFIX)/bin"
 
-	# Delete the anipy-cli in bin folder so that 
-	# the symlink can be made. It would fail if the 
+	# Delete the anipy-cli in bin folder so that
+	# the symlink can be made. It would fail if the
 	# old shell script was still there.
 	$(RM) $(PREFIX)/bin/anipy-cli
 	# Make a symlink to anipy-cli that is on the path
@@ -30,7 +30,7 @@ sys-install:
 	# Now install the program to lib
 	cp -r $(CURDIR) "$(PREFIX)/lib"
 
-	# Make it writable, so that the current default config works	
+	# Make it writable, so that the current default config works
 	chmod -R 777 $(PREFIX)/lib/anipy-cli
 
 uninstall:


### PR DESCRIPTION
The makefile was looking for "anipy-cli.py" instead of "anipy_cli.py". PR #37 fixed this, but it was closed before it was merged.

Both the "chmod" and "ln" contained in the makefile would fail/error because they could not find the correct file.

This has been changed in the makefile itself, as the "anipy_cli.py" file is named that way because of the formatter I assume. 