### PR TITLE
Give the option to get rid of the "(Dub)" at the end of the folder name when downloading anime

### DIFF
--- a/anipy_cli/config.py
+++ b/anipy_cli/config.py
@@ -29,7 +29,6 @@ except ImportError:
         # Ex. ~/Downloads/anipy would be Path('~/Downloads/anipy')
 
         download_folder_path = anipy_cli_folder / "download"
-        download_folder_path = Path.Home() / "anime"
         seasonals_dl_path = download_folder_path / "seasonals"
         user_files_path = anipy_cli_folder / "user_files"
         history_file_path = user_files_path / "history.json"

--- a/anipy_cli/config.py
+++ b/anipy_cli/config.py
@@ -29,6 +29,7 @@ except ImportError:
         # Ex. ~/Downloads/anipy would be Path('~/Downloads/anipy')
 
         download_folder_path = anipy_cli_folder / "download"
+        download_folder_path = Path.Home() / "anime"
         seasonals_dl_path = download_folder_path / "seasonals"
         user_files_path = anipy_cli_folder / "user_files"
         history_file_path = user_files_path / "history.json"
@@ -62,6 +63,9 @@ except ImportError:
         # This determines how downloaded anime will be named
         # The following variables can be used: show_name, episode_number, quality
         download_name_format = "{show_name}_{episode_number}.mp4"
+
+        # This removes the (Dub) in the anime title when downloading
+        download_remove_dub_from_folder_name = False
 
         # Discord Presence:
         # Show what you are watching on discord

--- a/anipy_cli/download.py
+++ b/anipy_cli/download.py
@@ -38,6 +38,18 @@ class download:
 
     def download(self):
         self.show_folder = config.download_folder_path / f"{self.entry.show_name}"
+        try:
+            if config.download_remove_dub_from_folder_name:
+                if self.entry.show_name.endswith(" (Dub)"):
+                    self.show_folder = (
+                        config.download_folder_path / f"{self.entry.show_name[:-6]}"
+                    )
+                    print(self.show_folder)
+        except AttributeError:
+            error(
+                "Config Option download_remove_dub_in_title is not set: please update your personal config file to include it"
+            )
+
         config.download_folder_path.mkdir(exist_ok=True)
         self.show_folder.mkdir(exist_ok=True)
         self.session = requests.Session()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name="anipy_cli",
     packages=find_packages(include=["anipy_cli"]),
-    version="2.4.20",
+    version="2.4.21",
     python_requires=">3.9",
     description="Little tool in python to watch anime from the terminal (the better way to watch anime)",
     long_description=long_description,


### PR DESCRIPTION
Yet another config option