### PR TITLE
Config File and Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ user_files/
 anipy_cli/config_personal.py
 pypi.sh
 .idea/
+
+# VSCode
+.vscode/
+
+# Venv
+.venv/

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Places of the config:
 
 [Sample Config](https://github.com/sdaqo/anipy-cli/blob/master/docs/sample_config.yaml)
 
-**Attention Windows Users:** If you activate the option `reuse_mpv_window`, you will have to donwload and put the `mpv-2.dll` in your path. To get it go look here: https://sourceforge.net/projects/mpv-player-windows/files/libmpv/
+**Attention Windows Users Using MPV:** If you activate the option `reuse_mpv_window`, you will have to download and put the `mpv-2.dll` in your path. To get it go look here: https://sourceforge.net/projects/mpv-player-windows/files/libmpv/
+
+**Attention Windows Users on Config File Placement:** If you have downloaded Python from the Microsoft Store, your config file will be cached inside of your Python's AppData. For example: `%USERPROFILE%\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\Local\anipy-cli\config.yaml`.
 
 # Usage
 

--- a/anipy_cli/config.py
+++ b/anipy_cli/config.py
@@ -14,8 +14,7 @@ class Config:
         self._config_file, self._yaml_conf = Config._read_config()
         
         if not self._yaml_conf:
-            # self._yaml_conf = {}
-            self._create_config()
+            self._create_config() # Create config file
 
     @property
     def _anipy_cli_folder(self):

--- a/anipy_cli/config.py
+++ b/anipy_cli/config.py
@@ -14,7 +14,8 @@ class Config:
         self._config_file, self._yaml_conf = Config._read_config()
         
         if not self._yaml_conf:
-            self._yaml_conf = {}
+            # self._yaml_conf = {}
+            self._create_config()
 
     @property
     def _anipy_cli_folder(self):


### PR DESCRIPTION
This pull request addresses #114, by mentioning sandboxed Python versions in the docs. It also creates a config file on launch so the user doesn't have to make one (I saw that there were no references to `_create_config()` inside the Config class). 