### PR TITLE
IINA player support

### DIFF
--- a/api/src/anipy_api/player/player.py
+++ b/api/src/anipy_api/player/player.py
@@ -40,7 +40,7 @@ def get_player(
     if Path(player.name).stem == "mpv-controlled":
         return MpvControllable(play_callback=play_callback)
 
-    player_dict = {"mpv": Mpv, "mpvnet": Mpv, "vlc": Vlc, "syncplay": Syncplay}
+    player_dict = {"mpv": Mpv, "mpvnet": Mpv, "vlc": Vlc, "syncplay": Syncplay, "iina": Iina}
 
     player_class = player_dict.get(Path(player.name).stem, None)
 

--- a/api/src/anipy_api/player/players/__init__.py
+++ b/api/src/anipy_api/player/players/__init__.py
@@ -2,6 +2,6 @@ from anipy_api.player.players.mpv import Mpv
 from anipy_api.player.players.vlc import Vlc
 from anipy_api.player.players.syncplay import Syncplay
 from anipy_api.player.players.mpv_control import MpvControllable
-from anipy_cli.player.players.iina import Iina
+from anipy_api.player.players.iina import Iina
 
 __all__ = ["Mpv", "Vlc", "Syncplay", "MpvControllable", "Iina"]

--- a/api/src/anipy_api/player/players/__init__.py
+++ b/api/src/anipy_api/player/players/__init__.py
@@ -2,5 +2,6 @@ from anipy_api.player.players.mpv import Mpv
 from anipy_api.player.players.vlc import Vlc
 from anipy_api.player.players.syncplay import Syncplay
 from anipy_api.player.players.mpv_control import MpvControllable
+from anipy_cli.player.players.iina import Iina
 
-__all__ = ["Mpv", "Vlc", "Syncplay", "MpvControllable"]
+__all__ = ["Mpv", "Vlc", "Syncplay", "MpvControllable", "Iina"]

--- a/api/src/anipy_api/player/players/iina.py
+++ b/api/src/anipy_api/player/players/iina.py
@@ -3,7 +3,7 @@ from anipy_api.player.base import SubProcessPlayerBase, PlayCallback
 
 
 class Iina(SubProcessPlayerBase):
-    """The [iina](https://iina.io) subprocess player class.
+    """The [vlc](https://www.videolan.org/vlc/) subprocess player class.
 
     For detailed documentation about the functions and arguments have a look at the [base class][anipy_api.player.base.SubProcessPlayerBase].
     """

--- a/api/src/anipy_api/player/players/iina.py
+++ b/api/src/anipy_api/player/players/iina.py
@@ -3,7 +3,7 @@ from anipy_api.player.base import SubProcessPlayerBase, PlayCallback
 
 
 class Iina(SubProcessPlayerBase):
-    """The [vlc](https://www.videolan.org/vlc/) subprocess player class.
+    """The [iina](https://iina.io) subprocess player class.
 
     For detailed documentation about the functions and arguments have a look at the [base class][anipy_api.player.base.SubProcessPlayerBase].
     """

--- a/api/src/anipy_api/player/players/iina.py
+++ b/api/src/anipy_api/player/players/iina.py
@@ -1,0 +1,32 @@
+from typing import List, Optional
+from anipy_api.player.base import SubProcessPlayerBase, PlayCallback
+
+
+class Iina(SubProcessPlayerBase):
+    """The [vlc](https://www.videolan.org/vlc/) subprocess player class.
+
+    For detailed documentation about the functions and arguments have a look at the [base class][anipy_api.player.base.SubProcessPlayerBase].
+    """
+
+    def __init__(
+        self,
+        player_path: str,
+        extra_args: List[str] = [],
+        play_callback: Optional[PlayCallback] = None,
+    ):
+        """__init__ of Iina
+
+        Args:
+            player_path:
+            extra_args:
+            play_callback:
+        """
+        self.player_args_template = [
+            "{stream_url}",
+            "--mpv-force-media-title={media_title}",
+            *extra_args,
+        ]
+
+        super().__init__(
+            player_path=player_path, extra_args=extra_args, play_callback=play_callback
+        )

--- a/cli/src/anipy_cli/arg_parser.py
+++ b/cli/src/anipy_cli/arg_parser.py
@@ -139,7 +139,7 @@ def parse_args(override_args: Optional[list[str]] = None) -> CliArgs:
         "-p",
         "--optional-player",
         required=False,
-        choices=["mpv", "vlc", "syncplay", "mpvnet", "mpv-controlled"],
+        choices=["mpv", "vlc", "iina", "syncplay", "mpvnet", "mpv-controlled"],
         help="Override the player set in the config.",
     )
 

--- a/cli/src/anipy_cli/config.py
+++ b/cli/src/anipy_cli/config.py
@@ -158,9 +158,6 @@ class Config:
         """
         return self._get_value("iina_commandline_options", [], list)
 
-
-
-
     @property
     def reuse_mpv_window(self) -> bool:
         """DEPRECATED This option was deprecated in 3.0.0, please use `mpv-

--- a/cli/src/anipy_cli/config.py
+++ b/cli/src/anipy_cli/config.py
@@ -150,6 +150,18 @@ class Config:
         return self._get_value("vlc_commandline_options", [], list)
 
     @property
+    def iina_commandline_options(self) -> List[str]:
+        """Extra commandline arguments for iina.
+
+        Examples:
+            iina_commandline_options: ["--mpv-fullscreen"]
+        """
+        return self._get_value("iina_commandline_options", [], list)
+
+
+
+
+    @property
     def reuse_mpv_window(self) -> bool:
         """DEPRECATED This option was deprecated in 3.0.0, please use `mpv-
         controlled` in the `player_path` instead!

--- a/cli/src/anipy_cli/util.py
+++ b/cli/src/anipy_cli/util.py
@@ -174,6 +174,8 @@ def get_configured_player(player_override: Optional[str] = None) -> "PlayerBase"
         args = config.mpv_commandline_options
     elif "vlc" in player.stem:
         args = config.vlc_commandline_options
+    elif "iina" in player.stem:
+        args = config.iina_commandline_options
     else:
         args = []
 


### PR DESCRIPTION
This adds support for IINA as a player (https://iina.io). I migrated to anipy-cli from ani-cli, and missed the ability to use IINA.

api:
- A player class for IINA has been added

cli:
- Ability to choose iina as the default player and include command line options has been added to the config file
- Overriding the default player with the "-p" argument can be performed