### PR TITLE
Fix "Remote Disconnected" Error

### DIFF
--- a/api/src/anipy_api/download.py
+++ b/api/src/anipy_api/download.py
@@ -273,7 +273,7 @@ class Downloader:
                 Containers may include all containers supported by FFmpeg e.g. ".mp4", ".mkv" etc...
             ffmpeg: Wheter to automatically default to
                 [ffmpeg_download][anipy_api.download.Downloader.ffmpeg_download] for m3u8/hls streams.
-            maxRetry: The amount of times the API can retry the download
+            max_retry: The amount of times the API can retry the download
 
         Returns:
             The path of the resulting file

--- a/api/src/anipy_api/provider/base.py
+++ b/api/src/anipy_api/provider/base.py
@@ -139,12 +139,19 @@ class BaseProvider(ABC):
             A brand new session
         """
         if hasattr(self, "session"):
-            print("Closing last session...")
             self.session.close()
         self.session = Session()
         return self.session
 
     def request_page(self, req: Request):
+        """Prepare a request and send it, but create a new session if self.session is broken
+        
+        Args:
+            req: The request
+
+        Returns:
+            out: Response of the request
+        """
         try:
             return request_page(self.session, req)
         except RequestConnectionError:

--- a/api/src/anipy_api/provider/base.py
+++ b/api/src/anipy_api/provider/base.py
@@ -121,7 +121,7 @@ class BaseProvider(ABC):
         if base_url_override is not None:
             self.BASE_URL = base_url_override
 
-        self.generate_new_session()
+        self._generate_new_session()
 
     def __init_subclass__(cls) -> None:
         for v in ["NAME", "BASE_URL", "FILTER_CAPS"]:
@@ -132,7 +132,7 @@ class BaseProvider(ABC):
                     )
                 )
 
-    def generate_new_session(self):
+    def _generate_new_session(self):
         """Close the last session, and create a new one.
 
         Returns:
@@ -143,7 +143,7 @@ class BaseProvider(ABC):
         self.session = Session()
         return self.session
 
-    def request_page(self, req: Request):
+    def _request_page(self, req: Request):
         """Prepare a request and send it, but create a new session if self.session is broken
         
         Args:
@@ -158,7 +158,7 @@ class BaseProvider(ABC):
             # If there is a connection error,
             # give it a second try with a
             # new session
-            return request_page(self.generate_new_session(), req)
+            return request_page(self._generate_new_session(), req)
 
     @abstractmethod
     def get_search(

--- a/api/src/anipy_api/provider/base.py
+++ b/api/src/anipy_api/provider/base.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Set, Union
 
-from requests import Request, Session
+from requests import Request, Session, ConnectionError as RequestConnectionError
 
 from anipy_api.provider.filter import FilterCapabilities, Filters, Status
 from anipy_api.provider.utils import request_page
@@ -147,7 +147,7 @@ class BaseProvider(ABC):
     def request_page(self, req: Request):
         try:
             return request_page(self.session, req)
-        except ConnectionError:
+        except RequestConnectionError:
             # If there is a connection error,
             # give it a second try with a
             # new session

--- a/api/src/anipy_api/provider/providers/gogo_provider.py
+++ b/api/src/anipy_api/provider/providers/gogo_provider.py
@@ -10,7 +10,7 @@ import m3u8
 from bs4 import BeautifulSoup
 from Cryptodome.Cipher import AES
 from requests import Request
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ConnectionError as RequestConnectionError
 
 from anipy_api.error import BeautifulSoupLocationError, LangTypeNotAvailableError
 from anipy_api.provider import (
@@ -28,10 +28,32 @@ from anipy_api.provider.filter import (
     Season,
     Status,
 )
-from anipy_api.provider.utils import parsenum, safe_attr
+from anipy_api.provider.utils import parsenum, request_page, safe_attr
 
 if TYPE_CHECKING:
     from anipy_api.provider import Episode
+    from requests import Session
+
+
+@functools.lru_cache()
+def _get_enc_keys(session: "Session", embed_url: str):
+    # This method is outside of the main class
+    # so the cache is not bound to the class
+    # instance
+    page = request_page(session, Request("GET", embed_url)).text
+
+    keys = re.findall(r"(?:container|videocontent)-(\d+)", page)
+
+    if not keys:
+        return {}
+
+    key, iv, second_key = keys
+
+    return {
+        "key": key.encode(),
+        "second_key": second_key.encode(),
+        "iv": iv.encode(),
+    }
 
 
 def _aes_encrypt(data, key, iv):
@@ -109,7 +131,7 @@ class GoGoProvider(BaseProvider):
         req = Request("GET", search_url)
         req = GoGoFilter(req).apply(query, filters)
 
-        res = self.request_page(req)
+        res = self._request_page(req)
         soup = BeautifulSoup(res.content, "html.parser")
 
         pages = soup.find_all("a", attrs={"data-page": re.compile(r"^ *\d[\d ]*$")})
@@ -123,7 +145,7 @@ class GoGoProvider(BaseProvider):
 
         for p in range(pages):
             req.params["page"] = p + 1
-            res = self.request_page(req)
+            res = self._request_page(req)
             soup = BeautifulSoup(res.content, "html.parser")
             links = soup.find_all("p", attrs={"class": "name"})
             if links is None:
@@ -164,7 +186,7 @@ class GoGoProvider(BaseProvider):
 
     def get_info(self, identifier: str) -> "ProviderInfoResult":
         req = Request("GET", f"{self.BASE_URL}/category/{identifier}")
-        res = self.request_page(req)
+        res = self._request_page(req)
 
         soup = BeautifulSoup(res.text, "html.parser")
         info_body = soup.find("div", {"class": "anime_info_body_bg"})
@@ -219,7 +241,7 @@ class GoGoProvider(BaseProvider):
         for u in urls:
             try:
                 req = Request("GET", u)
-                res = self.request_page(req)
+                res = self._request_page(req)
                 break
             except HTTPError:
                 continue
@@ -236,7 +258,7 @@ class GoGoProvider(BaseProvider):
                 raise LangTypeNotAvailableError(identifier, self.NAME, lang)
             else:
                 req = Request("GET", f"{self.BASE_URL}{filtered_res[0]}")
-                res = self.request_page(req)
+                res = self._request_page(req)
 
         soup = BeautifulSoup(res.content, "html.parser")
         link = soup.find("a", {"class": "active", "rel": "1"})
@@ -247,7 +269,7 @@ class GoGoProvider(BaseProvider):
         embed_url: str = link["data-video"]
 
         req = Request("GET", embed_url)
-        res = self.request_page(req)
+        res = self._request_page(req)
 
         soup = BeautifulSoup(res.content, "html.parser")
         crypto = soup.find("script", {"data-name": "episode"})
@@ -275,7 +297,7 @@ class GoGoProvider(BaseProvider):
             ajax_url + urlencode(data) + f"&alias={id_param}",
             headers=headers,
         )
-        res = self.request_page(req)
+        res = self._request_page(req)
 
         json_res = json.loads(
             _aes_decrypt(res.json().get("data"), enc_keys["second_key"], enc_keys["iv"])
@@ -287,7 +309,7 @@ class GoGoProvider(BaseProvider):
         for s in source_data:
             if s["type"] == "hls":
                 req = Request("GET", s["file"])
-                res = self.request_page(req)
+                res = self._request_page(req)
                 content = m3u8.M3U8(res.text, base_uri=urljoin(res.url, "."))
                 if len(content.playlists) == 0:
                     streams.append(
@@ -336,7 +358,7 @@ class GoGoProvider(BaseProvider):
         for u in urls:
             try:
                 req = Request("GET", u)
-                res = self.request_page(req)
+                res = self._request_page(req)
                 break
             except HTTPError:
                 continue
@@ -353,7 +375,7 @@ class GoGoProvider(BaseProvider):
             "https://ajax.gogocdn.net/ajax/load-list-episode",
             params={"ep_start": 0, "ep_end": 9999, "id": self.movie_id},
         )
-        res = self.request_page(req)
+        res = self._request_page(req)
 
         ep_list = [
             (
@@ -370,19 +392,9 @@ class GoGoProvider(BaseProvider):
 
         return ep_list
 
-    @functools.lru_cache()
     def _get_enc_keys(self, embed_url: str):
-        page = self.request_page(Request("GET", embed_url)).text
-
-        keys = re.findall(r"(?:container|videocontent)-(\d+)", page)
-
-        if not keys:
-            return {}
-
-        key, iv, second_key = keys
-
-        return {
-            "key": key.encode(),
-            "second_key": second_key.encode(),
-            "iv": iv.encode(),
-        }
+        try:
+            return _get_enc_keys(self.session, embed_url)
+        except RequestConnectionError:
+            return _get_enc_keys(self._generate_new_session(), embed_url)
+        

--- a/api/src/anipy_api/provider/providers/gogo_provider.py
+++ b/api/src/anipy_api/provider/providers/gogo_provider.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qsl, urlencode, urljoin, urlparse
 import m3u8
 from bs4 import BeautifulSoup
 from Cryptodome.Cipher import AES
-from requests import Request, Session
+from requests import Request
 from requests.exceptions import HTTPError
 
 from anipy_api.error import BeautifulSoupLocationError, LangTypeNotAvailableError
@@ -28,28 +28,10 @@ from anipy_api.provider.filter import (
     Season,
     Status,
 )
-from anipy_api.provider.utils import parsenum, request_page, safe_attr
+from anipy_api.provider.utils import parsenum, safe_attr
 
 if TYPE_CHECKING:
     from anipy_api.provider import Episode
-
-
-@functools.lru_cache()
-def _get_enc_keys(session: Session, embed_url: str):
-    page = request_page(session, Request("GET", embed_url)).text
-
-    keys = re.findall(r"(?:container|videocontent)-(\d+)", page)
-
-    if not keys:
-        return {}
-
-    key, iv, second_key = keys
-
-    return {
-        "key": key.encode(),
-        "second_key": second_key.encode(),
-        "iv": iv.encode(),
-    }
 
 
 def _aes_encrypt(data, key, iv):
@@ -127,7 +109,7 @@ class GoGoProvider(BaseProvider):
         req = Request("GET", search_url)
         req = GoGoFilter(req).apply(query, filters)
 
-        res = request_page(self.session, req)
+        res = self.request_page(req)
         soup = BeautifulSoup(res.content, "html.parser")
 
         pages = soup.find_all("a", attrs={"data-page": re.compile(r"^ *\d[\d ]*$")})
@@ -141,7 +123,7 @@ class GoGoProvider(BaseProvider):
 
         for p in range(pages):
             req.params["page"] = p + 1
-            res = request_page(self.session, req)
+            res = self.request_page(req)
             soup = BeautifulSoup(res.content, "html.parser")
             links = soup.find_all("p", attrs={"class": "name"})
             if links is None:
@@ -182,7 +164,7 @@ class GoGoProvider(BaseProvider):
 
     def get_info(self, identifier: str) -> "ProviderInfoResult":
         req = Request("GET", f"{self.BASE_URL}/category/{identifier}")
-        res = request_page(self.session, req)
+        res = self.request_page(req)
 
         soup = BeautifulSoup(res.text, "html.parser")
         info_body = soup.find("div", {"class": "anime_info_body_bg"})
@@ -237,7 +219,7 @@ class GoGoProvider(BaseProvider):
         for u in urls:
             try:
                 req = Request("GET", u)
-                res = request_page(self.session, req)
+                res = self.request_page(req)
                 break
             except HTTPError:
                 continue
@@ -254,7 +236,7 @@ class GoGoProvider(BaseProvider):
                 raise LangTypeNotAvailableError(identifier, self.NAME, lang)
             else:
                 req = Request("GET", f"{self.BASE_URL}{filtered_res[0]}")
-                res = request_page(self.session, req)
+                res = self.request_page(req)
 
         soup = BeautifulSoup(res.content, "html.parser")
         link = soup.find("a", {"class": "active", "rel": "1"})
@@ -265,7 +247,7 @@ class GoGoProvider(BaseProvider):
         embed_url: str = link["data-video"]
 
         req = Request("GET", embed_url)
-        res = request_page(self.session, req)
+        res = self.request_page(req)
 
         soup = BeautifulSoup(res.content, "html.parser")
         crypto = soup.find("script", {"data-name": "episode"})
@@ -293,7 +275,7 @@ class GoGoProvider(BaseProvider):
             ajax_url + urlencode(data) + f"&alias={id_param}",
             headers=headers,
         )
-        res = request_page(self.session, req)
+        res = self.request_page(req)
 
         json_res = json.loads(
             _aes_decrypt(res.json().get("data"), enc_keys["second_key"], enc_keys["iv"])
@@ -305,7 +287,7 @@ class GoGoProvider(BaseProvider):
         for s in source_data:
             if s["type"] == "hls":
                 req = Request("GET", s["file"])
-                res = request_page(self.session, req)
+                res = self.request_page(req)
                 content = m3u8.M3U8(res.text, base_uri=urljoin(res.url, "."))
                 if len(content.playlists) == 0:
                     streams.append(
@@ -354,7 +336,7 @@ class GoGoProvider(BaseProvider):
         for u in urls:
             try:
                 req = Request("GET", u)
-                res = request_page(self.session, req)
+                res = self.request_page(req)
                 break
             except HTTPError:
                 continue
@@ -371,7 +353,7 @@ class GoGoProvider(BaseProvider):
             "https://ajax.gogocdn.net/ajax/load-list-episode",
             params={"ep_start": 0, "ep_end": 9999, "id": self.movie_id},
         )
-        res = request_page(self.session, req)
+        res = self.request_page(req)
 
         ep_list = [
             (
@@ -387,3 +369,20 @@ class GoGoProvider(BaseProvider):
         ep_list.reverse()
 
         return ep_list
+
+    @functools.lru_cache()
+    def _get_enc_keys(self, embed_url: str):
+        page = self.request_page(Request("GET", embed_url)).text
+
+        keys = re.findall(r"(?:container|videocontent)-(\d+)", page)
+
+        if not keys:
+            return {}
+
+        key, iv, second_key = keys
+
+        return {
+            "key": key.encode(),
+            "second_key": second_key.encode(),
+            "iv": iv.encode(),
+        }

--- a/api/src/anipy_api/provider/providers/gogo_provider.py
+++ b/api/src/anipy_api/provider/providers/gogo_provider.py
@@ -260,7 +260,7 @@ class GoGoProvider(BaseProvider):
         parsed = urlparse(embed_url)
         ajax_url = f"{parsed.scheme}://{parsed.netloc}/encrypt-ajax.php?"
 
-        enc_keys = _get_enc_keys(self.session, embed_url)
+        enc_keys = self._get_enc_keys(embed_url)
         data = _aes_decrypt(crypto, enc_keys["key"], enc_keys["iv"]).decode()
         data = dict(parse_qsl(data))
 

--- a/api/src/anipy_api/provider/providers/yugen_provider.py
+++ b/api/src/anipy_api/provider/providers/yugen_provider.py
@@ -91,7 +91,7 @@ class YugenProvider(BaseProvider):
         page = 0
         while has_next:
             req.params["page"] = page + 1
-            res = self.request_page(req).json()
+            res = self._request_page(req).json()
             has_next = res["hasNext"]
 
             soup = BeautifulSoup(res.get("query"), "html.parser")
@@ -129,7 +129,7 @@ class YugenProvider(BaseProvider):
     def get_episodes(self, identifier: str, lang: LanguageTypeEnum) -> List["Episode"]:
         identifier = base64.b64decode(identifier).decode()
         req = Request("GET", f"{self.BASE_URL}/anime/{identifier}")
-        result = self.request_page(req)
+        result = self._request_page(req)
 
         if lang == LanguageTypeEnum.SUB:
             match = re.search(
@@ -151,7 +151,7 @@ class YugenProvider(BaseProvider):
     def get_info(self, identifier: str) -> "ProviderInfoResult":
         identifier = base64.b64decode(identifier).decode()
         req = Request("GET", f"{self.BASE_URL}/anime/{identifier}")
-        result = self.request_page(req)
+        result = self._request_page(req)
         data_map = {
             "name": None,
             "image": None,
@@ -225,12 +225,12 @@ class YugenProvider(BaseProvider):
             },
             headers={"x-requested-with": "XMLHttpRequest"},
         )
-        res = self.request_page(req)
+        res = self._request_page(req)
         res = res.json()
         streams = []
         for playlist in res["hls"]:
             req = Request("GET", playlist)
-            res = self.request_page(req)
+            res = self._request_page(req)
             content = m3u8.M3U8(res.text, base_uri=urljoin(res.url, "."))
             if len(content.playlists) == 0:
                 streams.append(

--- a/api/src/anipy_api/provider/providers/yugen_provider.py
+++ b/api/src/anipy_api/provider/providers/yugen_provider.py
@@ -23,7 +23,6 @@ from anipy_api.provider.filter import (
     Season,
     Status,
 )
-from anipy_api.provider.utils import request_page
 
 if TYPE_CHECKING:
     from anipy_api.provider import Episode
@@ -92,7 +91,7 @@ class YugenProvider(BaseProvider):
         page = 0
         while has_next:
             req.params["page"] = page + 1
-            res = request_page(self.session, req).json()
+            res = self.request_page(req).json()
             has_next = res["hasNext"]
 
             soup = BeautifulSoup(res.get("query"), "html.parser")
@@ -130,7 +129,7 @@ class YugenProvider(BaseProvider):
     def get_episodes(self, identifier: str, lang: LanguageTypeEnum) -> List["Episode"]:
         identifier = base64.b64decode(identifier).decode()
         req = Request("GET", f"{self.BASE_URL}/anime/{identifier}")
-        result = request_page(self.session, req)
+        result = self.request_page(req)
 
         if lang == LanguageTypeEnum.SUB:
             match = re.search(
@@ -152,7 +151,7 @@ class YugenProvider(BaseProvider):
     def get_info(self, identifier: str) -> "ProviderInfoResult":
         identifier = base64.b64decode(identifier).decode()
         req = Request("GET", f"{self.BASE_URL}/anime/{identifier}")
-        result = request_page(self.session, req)
+        result = self.request_page(req)
         data_map = {
             "name": None,
             "image": None,
@@ -226,12 +225,12 @@ class YugenProvider(BaseProvider):
             },
             headers={"x-requested-with": "XMLHttpRequest"},
         )
-        res = request_page(self.session, req)
+        res = self.request_page(req)
         res = res.json()
         streams = []
         for playlist in res["hls"]:
             req = Request("GET", playlist)
-            res = request_page(self.session, req)
+            res = self.request_page(req)
             content = m3u8.M3U8(res.text, base_uri=urljoin(res.url, "."))
             if len(content.playlists) == 0:
                 streams.append(

--- a/cli/poetry.lock
+++ b/cli/poetry.lock
@@ -236,14 +236,17 @@ typing-inspect = ">=0.4.0,<1"
 
 [[package]]
 name = "idna"
-version = "3.8"
+version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "idna-3.8-py3-none-any.whl", hash = "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac"},
-    {file = "idna-3.8.tar.gz", hash = "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"},
+    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
+    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
 ]
+
+[package.extras]
+all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "inquirerpy"


### PR DESCRIPTION
This solves #197 by creating a method inside of the base provider for requesting pages and another for creating a new session. If requesting the page causes an error, it will create a new session to try again (in case of a broken connection).

The reason I added a function for creating a session is for if a future provider were to require cookies or a password, thus it can override this function.

I don't mind the nitpicks; hopefully this change will be easier to follow and less intense than the last PR lol.