### PR TITLE
Fix MAL mode 0 episode bug

### DIFF
--- a/api/src/anipy_api/player/base.py
+++ b/api/src/anipy_api/player/base.py
@@ -167,7 +167,9 @@ class SubProcessPlayerBase(PlayerBase):
             if os.name in ("nt", "dos"):
                 sub_proc = sp.Popen(player_command)
             else:
-                sub_proc = sp.Popen(player_command, stdout=sp.DEVNULL, stderr=sp.DEVNULL)
+                sub_proc = sp.Popen(
+                    player_command, stdout=sp.DEVNULL, stderr=sp.DEVNULL
+                )
         except FileNotFoundError:
             raise PlayerError(f"Executable {player_command[0]} was not found")
 

--- a/api/src/anipy_api/provider/base.py
+++ b/api/src/anipy_api/provider/base.py
@@ -145,7 +145,7 @@ class BaseProvider(ABC):
 
     def _request_page(self, req: Request):
         """Prepare a request and send it, but create a new session if self.session is broken
-        
+
         Args:
             req: The request
 

--- a/api/src/anipy_api/provider/providers/gogo_provider.py
+++ b/api/src/anipy_api/provider/providers/gogo_provider.py
@@ -397,4 +397,3 @@ class GoGoProvider(BaseProvider):
             return _get_enc_keys(self.session, embed_url)
         except RequestConnectionError:
             return _get_enc_keys(self._generate_new_session(), embed_url)
-        

--- a/cli/src/anipy_cli/menus/mal_menu.py
+++ b/cli/src/anipy_cli/menus/mal_menu.py
@@ -433,7 +433,7 @@ class MALMenu(MenuBase):
                     )
                 elif e.num_episodes == 0:
                     episodes_to_watch = list(
-                        range(e.my_list_status.num_episodes_watched + 1, 101)  # type: ignore
+                        range(e.my_list_status.num_episodes_watched + 1, 10000)  # type: ignore
                     )
 
                 result = self.mal_proxy.map_from_mal(e)

--- a/cli/src/anipy_cli/menus/mal_menu.py
+++ b/cli/src/anipy_cli/menus/mal_menu.py
@@ -433,7 +433,7 @@ class MALMenu(MenuBase):
                     )
                 elif e.num_episodes == 0:
                     episodes_to_watch = list(
-                        range(e.my_list_status.num_episodes_watched + 1, e.my_list_status.num_episodes_watched + 2)  # type: ignore
+                        range(e.my_list_status.num_episodes_watched + 1, 101)  # type: ignore
                     )
 
                 result = self.mal_proxy.map_from_mal(e)

--- a/cli/src/anipy_cli/menus/mal_menu.py
+++ b/cli/src/anipy_cli/menus/mal_menu.py
@@ -390,7 +390,9 @@ class MALMenu(MenuBase):
                 mylist.pop(i)
                 continue
 
-            if e.my_list_status.num_episodes_watched == e.num_episodes:
+            if (e.my_list_status.num_episodes_watched == e.num_episodes) and (
+                e.my_list_status.num_episodes_watched != 0
+            ):
                 mylist.pop(i)
 
         if not mylist:

--- a/cli/src/anipy_cli/menus/mal_menu.py
+++ b/cli/src/anipy_cli/menus/mal_menu.py
@@ -481,6 +481,8 @@ class MALMenu(MenuBase):
                             s.write(
                                 f"> Episode {ep} not found in provider, skipping..."
                             )
+                            if e.num_episodes == 0:
+                                break
 
                 to_watch.append((result, e, lang, will_watch))
 

--- a/cli/src/anipy_cli/menus/mal_menu.py
+++ b/cli/src/anipy_cli/menus/mal_menu.py
@@ -427,9 +427,14 @@ class MALMenu(MenuBase):
             for e in mylist:
                 s.write(f"> Checking out episodes of {e.title}")
 
-                episodes_to_watch = list(
-                    range(e.my_list_status.num_episodes_watched + 1, e.num_episodes + 1)  # type: ignore
-                )
+                if e.num_episodes != 0:
+                    episodes_to_watch = list(
+                        range(e.my_list_status.num_episodes_watched + 1, e.num_episodes + 1)  # type: ignore
+                    )
+                elif e.num_episodes == 0:
+                    episodes_to_watch = list(
+                        range(e.my_list_status.num_episodes_watched + 1, e.my_list_status.num_episodes_watched + 2)  # type: ignore
+                    )
 
                 result = self.mal_proxy.map_from_mal(e)
 


### PR DESCRIPTION
Fixed a bug that was causing MAL mode not to display an anime if no episodes had been watched and MAL didn't list the total number of episodes yet (i.e. for some anime that are still airing)