### PR TITLE
Add Linux installer script for anipy-cli using a Python virtual environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ As one wise man once said:
 
 We do not have an .exe, but we have pipx: `pipx install anipy-cli`
 
+For our linux nerds just run this script
+
+```bash
+curl -s https://raw.githubusercontent.com/sdaqo/anipy-cli/refs/heads/master/install-linux.sh | bash
+```
+
 Check out [Getting Started - CLI](https://sdaqo.github.io/anipy-cli/getting-started-cli) for more installation options (pip, nix) and advice!
 
 ## You want to use the api for your project?

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+if ! [[ -d $HOME/.local/share/anipy-cli-venv-install ]]; then
+  echo creating a python virtual environment
+  mkdir $HOME/.local/share/anipy-cli-venv-install
+  python -m venv $HOME/.local/share/anipy-cli-venv-install/venv
+else
+  echo "environment already found"
+fi
+
+if ! [[ -f $HOME/.local/share/anipy-cli-venv-install/venv/bin/anipy-cli ]]; then
+  echo installing anipy-cli-venv-install
+  source $HOME/.local/share/anipy-cli-venv-install/venv/bin/activate
+  pip install --upgrade pip
+  pip install anipy-cli
+  deactivate
+else
+  echo "anipy-cli already installed"
+fi
+
+if ! [[ -f $HOME/.local/bin/anipy-cli ]]; then
+  echo creating symlink
+  ln -s $HOME/.local/share/anipy-cli-venv-install/venv/bin/anipy-cli $HOME/.local/bin/anipy-cli
+else
+  echo "symlink already created"
+fi
+
+if ! [[ -f $HOME/.local/bin/anipy-cli-update ]]; then
+  echo "creating update script"
+  echo "#!/bin/bash
+  source \$HOME/.local/share/anipy-cli-venv-install/venv/bin/activate
+  pip install --upgrade pip
+  pip install --upgrade anipy-cli
+  deactivate
+  rm \$HOME/.local/bin/anipy-cli 
+  ln -s \$HOME/.local/share/anipy-cli-venv-install/venv/bin/anipy-cli \$HOME/.local/bin/anipy-cli
+   " | sed -e 's/^ *//g' >$HOME/.local/bin/anipy-cli-update
+  chmod +x $HOME/.local/bin/anipy-cli-update
+else
+  echo "update script already created"
+fi
+
+if ! [[ -f $HOME/.local/bin/anipy-cli-uninstall ]]; then
+  echo "creating uninstall script"
+  echo "#!/bin/bash
+  rm -r \$HOME/.local/share/anipy-cli-venv-install 
+  rm \$HOME/.local/bin/anipy-cli
+  rm \$HOME/.local/bin/anipy-cli-update
+  rm \$HOME/.local/bin/anipy-cli-uninstall
+  " | sed -e 's/^ *//g' >$HOME/.local/bin/anipy-cli-uninstall
+  chmod +x $HOME/.local/bin/anipy-cli-uninstall
+else
+  echo "uninstall script already created"
+fi


### PR DESCRIPTION
### Problem Statement

* anipy-cli is primarily distributed through `pip`. 
* Installing Python applications system-wide with `pip` is generally discouraged on Linux systems because it can conflict with distribution-managed packages.
* `anipy-cli` is not currently available in the official repositories or in the Arch User Repository (AUR).
* Manual installation requires creating a Python virtual environment, installing the package, creating symlinks in `~/.local/bin`, and handling updates and removal manually.

### Solution

This pull request adds an installation script that automates the complete setup and management process at the user level.

The script:

* Creates a dedicated Python virtual environment in `~/.local/share/anipy-cli-venv-install`
* Installs `anipy-cli` and its dependencies using `pip`
* Creates symlinks in `~/.local/bin` so the `anipy` command is available in the user's `PATH`
* Generates an `anipy-cli-update` script to upgrade the installation
* Generates an `anipy-cli-uninstall` script to remove all related files and symlinks

### Purpose

The goal of this script is to provide Linux users with a simple way to install, update, and uninstall `anipy-cli` without manually managing a Python virtual environment.

This makes the installation process as straightforward as running a single script, while keeping the application isolated from the system Python environment and avoiding the need to wait for a distribution-specific package to become available.

[1]: https://github.com/sdaqo/anipy-cli?utm_source=chatgpt.com "GitHub - sdaqo/anipy-cli: Little tool in python to watch and download anime from the terminal (the better way to watch anime). Also applicable as an API"