### PR TITLE
fix: sanitize illegal filename chars on Android shared storage

### DIFF
--- a/api/src/anipy_api/download.py
+++ b/api/src/anipy_api/download.py
@@ -88,9 +88,6 @@ class Downloader:
 
     @staticmethod
     def _get_valid_pathname(name: str):
-        # Windows and Android shared storage (FAT/exFAT/NTFS) share the same
-        # set of forbidden characters. Android is detected via env vars that
-        # are always present in Termux and other Android environments.
         is_android = "ANDROID_ROOT" in os.environ or "ANDROID_DATA" in os.environ
         if sys.platform == "win32" or is_android:
             invalid_chars = ["\\", "/", ":", "*", "?", "<", ">", "|", '"', "."]

--- a/api/src/anipy_api/download.py
+++ b/api/src/anipy_api/download.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -87,7 +88,11 @@ class Downloader:
 
     @staticmethod
     def _get_valid_pathname(name: str):
-        if sys.platform == "win32":
+        # Windows and Android shared storage (FAT/exFAT/NTFS) share the same
+        # set of forbidden characters. Android is detected via env vars that
+        # are always present in Termux and other Android environments.
+        is_android = "ANDROID_ROOT" in os.environ or "ANDROID_DATA" in os.environ
+        if sys.platform == "win32" or is_android:
             invalid_chars = ["\\", "/", ":", "*", "?", "<", ">", "|", '"', "."]
         else:
             invalid_chars = [".", "/"]


### PR DESCRIPTION
## Problem
Anime titles containing `:` and other special characters (e.g. 
`Jujutsu Kaisen: Shimetsu Kaiyuu - Zenpen`) cause downloads to fail 
with `Error opening output files: Operation not permitted` on Android 
shared storage outside Termux's home directory.

Android's FAT/exFAT/NTFS-formatted shared storage forbids the same 
characters as Windows (`:`  `*`  `?`  `"`  `<`  `>`  `|`  `\`), but 
the existing code only applied strict sanitization on `sys.platform == 
"win32"`.

## Fix
Detect Android via the `ANDROID_ROOT` / `ANDROID_DATA` environment 
variables (always set in Termux) and apply the same character 
exclusion list used for Windows.

## Testing
Tested with titles containing `:` downloaded to 
`/storage/emulated/0/` — downloads now succeed.

Fixes #310