### PR TITLE
fix: decrypt AllAnime tobeparsed with either key

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "anipy-api"
-version = "3.8.14"
+version = "3.8.15"
 description = "api for anipy-cli"
 authors = ["sdaqo <sdaqo.dev@protonmail.com>"]
 license = "GPL-3.0"

--- a/api/src/anipy_api/__init__.py
+++ b/api/src/anipy_api/__init__.py
@@ -1,2 +1,2 @@
 __appname__ = "anipy-api"
-__version__ = "3.8.14"
+__version__ = "3.8.15"

--- a/api/src/anipy_api/provider/providers/allanime_provider.py
+++ b/api/src/anipy_api/provider/providers/allanime_provider.py
@@ -57,6 +57,8 @@ class AllAnimeCrypto:
     FALLBACK_QUERY_HASH = (
         "d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec"
     )
+    # AllAnime encrypts the tobeparsed response with either the aaReq key or this static legacy key, depending on the rotation, so decoding tries both.
+    RESPONSE_STATIC_KEY = hashlib.sha256(b"Xot36i3lK3:v1").digest()
 
     def __init__(self, info_callback: Optional[Callable[[str], None]] = None):
         self._info: Callable[[str], None] = info_callback or (lambda message: None)
@@ -198,12 +200,24 @@ class AllAnimeCrypto:
         token = base64.b64encode(b"\x01" + iv + ciphertext + tag).decode()
         return query_hash, token, key
 
+    def invalidate(self):
+        """Drop the cached crypto so the next request refetches it."""
+        self._cache = None
+
     @staticmethod
     def decode_tobeparsed(tbp: str, key: bytes):
         raw = base64.b64decode(tbp)
         iv, ciphertext, tag = raw[1:13], raw[13:-16], raw[-16:]
-        cipher = AES.new(key, AES.MODE_GCM, nonce=iv)
-        return json.loads(cipher.decrypt_and_verify(ciphertext, tag).decode("utf-8"))
+
+        # The response is signed with either the aaReq key or the static legacy key, so try both and use whichever authenticates.
+        for candidate in (key, AllAnimeCrypto.RESPONSE_STATIC_KEY):
+            try:
+                cipher = AES.new(candidate, AES.MODE_GCM, nonce=iv)
+                plain = cipher.decrypt_and_verify(ciphertext, tag)
+                return json.loads(plain.decode("utf-8"))
+            except ValueError:
+                continue
+        raise ValueError("tobeparsed could not be decrypted with any known key")
 
 
 class AllAnimeFilter(BaseFilter):
@@ -416,7 +430,12 @@ class AllAnimeProvider(BaseProvider):
 
         data = result.get("data") or {}
         if "tobeparsed" in data:
-            data = self._crypto.decode_tobeparsed(data["tobeparsed"], key)
+            try:
+                data = self._crypto.decode_tobeparsed(data["tobeparsed"], key)
+            except ValueError:
+                # Crypto rotated between the aaReq and the response, drop the cache so the next attempt refetches, and return no streams instead of crashing.
+                self._crypto.invalidate()
+                return streams
 
         if not data.get("episode"):
             return streams

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "anipy-cli"
-version = "3.8.14"
+version = "3.8.15"
 description = "Watch and Download anime from the comfort of your Terminal"
 authors = ["sdaqo <sdaqo.dev@protonmail.com>"]
 license = "GPL-3.0"
@@ -20,7 +20,7 @@ yaspin = "^3.0.2"
 inquirerpy = "^0.3.4"
 appdirs = "^1.4.4"
 pypresence = "^4.3.0"
-anipy-api = "^3.8.14"
+anipy-api = "^3.8.15"
 
 [tool.poetry.scripts]
 anipy-cli = "anipy_cli.cli:run_cli"

--- a/cli/src/anipy_cli/__init__.py
+++ b/cli/src/anipy_cli/__init__.py
@@ -1,2 +1,2 @@
 __appname__ = "anipy-cli"
-__version__ = "3.8.14"
+__version__ = "3.8.15"


### PR DESCRIPTION
# fix: decrypt AllAnime tobeparsed with either key

Follow up to the aaReq runtime fetch (#333). Some user hit a hard crash on playback (https://github.com/sdaqo/anipy-cli/issues/334):

```
CRITICAL - A fatal error has occurred - MAC check failed
  ...
  File ".../allanime_provider.py", line 419, in get_video
    data = self._crypto.decode_tobeparsed(data["tobeparsed"], key)
  ...
ValueError: MAC check failed
```


## Root cause

The aaReq token is signed with the runtime key (`mask xor partB`) and that part is fine. The bug is on the response side: AllAnime encrypts the `tobeparsed` payload with **either** that same aaReq key **or** the old static key
`sha256("Xot36i3lK3:v1")`, depending on the current rotation.

`decode_tobeparsed` only tried the aaReq key, so whenever AllAnime served a response signed with the legacy key the AES-GCM verification failed with `MAC check failed`. Since the call was not guarded, the whole program crashed instead of just reporting no sources.

I confirmed it live: with the current rotation the response only decrypts with the legacy key.

```
fetched key (mask^partB): ValueError
old sha256 Xot36i3lK3:v1: DECRYPT OK
```

That is also why it was intermittent "sometimes". It depends on which key AllAnime happens to use for the response at that moment.

## The fix

- `decode_tobeparsed` now tries both keys (the aaReq key and the static legacy
  key) and uses whichever authenticates.
- If neither works, `get_video` drops the cached crypto and returns no streams instead of crashing, so a bad rotation window degrades to the normal "no valid sources" path.

No new dependencies, no behaviour change when the aaReq key already works.

## Testing

I tested it against the live API with the following anime:

- Naruto
- one piece
- frieren

Before this change those raised `MAC check failed` and crashed.
