### PR TITLE
fix: add mkissa as origin in requests

### DIFF
--- a/api/src/anipy_api/provider/providers/allanime_provider.py
+++ b/api/src/anipy_api/provider/providers/allanime_provider.py
@@ -316,7 +316,10 @@ class AllAnimeProvider(BaseProvider):
                     }
                 ),
             },
-            headers={"Referer": "https://youtu-chan.com/"},
+            headers={
+                "Referer": "https://youtu-chan.com/",
+                "Origin": "https://mkissa.to",
+            },
         )
         result = self._request_page(req).json()
         providers = ["Yt-mp4", "S-Mp4", "Uv-mp4", "Ak", "Default"]


### PR DESCRIPTION
Seems that due to some [AllAnime and MKissa drama](https://www.reddit.com/r/allanimesite/s/MjxK4FMerA), this is now required for requests.

Based on https://github.com/pystardust/ani-cli/pull/1801/.

Closes #343