### PR TITLE
fix: limiting M3U8 segment filename length

### DIFF
--- a/api/src/anipy_api/download.py
+++ b/api/src/anipy_api/download.py
@@ -100,7 +100,6 @@ class Downloader:
         return name
 
     MAX_SEGMENT_NAME_LENGTH = 200
-    # the max length of a filename depends on the OS, but 200 fits most OSes
 
     def m3u8_download(self, stream: "ProviderStream", download_path: Path) -> Path:
         """Download a m3u8/hls stream to a specified download path in a ts container.

--- a/api/src/anipy_api/download.py
+++ b/api/src/anipy_api/download.py
@@ -99,6 +99,9 @@ class Downloader:
 
         return name
 
+    MAX_SEGMENT_NAME_LENGTH = 200
+    # the max length of a filename depends on the OS, but 200 fits most OSes
+
     def m3u8_download(self, stream: "ProviderStream", download_path: Path) -> Path:
         """Download a m3u8/hls stream to a specified download path in a ts container.
 
@@ -131,9 +134,9 @@ class Downloader:
             nonlocal counter
             url = urljoin(segment.base_uri, segment.uri)
             segment_uri = Path(segment.uri)
-            fname = (
-                temp_folder / self._get_valid_pathname(segment_uri.stem)
-            ).with_suffix(segment_uri.suffix)
+            segment_name = self._get_valid_pathname(segment_uri.stem)
+            segment_name = segment_name[: self.MAX_SEGMENT_NAME_LENGTH]
+            fname = (temp_folder / segment_name).with_suffix(segment_uri.suffix)
             try:
                 res = self._session.get(str(url), headers={"Referer": stream.referrer})
                 res.raise_for_status()
@@ -170,9 +173,9 @@ class Downloader:
             with download_path.open("wb") as merged:
                 for segment in m3u8_content.segments:
                     uri = Path(segment.uri)
-                    fname = (
-                        temp_folder / self._get_valid_pathname(uri.stem)
-                    ).with_suffix(uri.suffix)
+                    segment_name = self._get_valid_pathname(uri.stem)
+                    segment_name = segment_name[: self.MAX_SEGMENT_NAME_LENGTH]
+                    fname = (temp_folder / segment_name).with_suffix(uri.suffix)
                     if not fname.is_file():
                         raise DownloadError(
                             f"Could not merge, missing a segment of this playlist: {stream.url}"


### PR DESCRIPTION
Fixes #355

Some titles generate a long segment_uri, which gets used for the temporary M3U8 segments. This would throw an error that the filename was too long, so I set a 200-character limit.

I chose 200 as a conservative limit since maximum filename lengths vary across filesystems


I tested by downloading all the titles in the issue above, and they worked 